### PR TITLE
Add py-multibase dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ setup(
                         'mnemonic>=0.20',
                         'PrettyTable>=3.5.0',
                         'http_sfv>=0.9.8',
-                        'cryptography>=39.0.2'
+                        'cryptography>=39.0.2',
+                        'py-multibase>=1.0.3'
     ],
     extras_require={
     },


### PR DESCRIPTION
It looks like https://github.com/hyperledger-labs/did-webs-resolver/commit/2263a3ecb3652e4a884a3cc91623d51c8dbabab0 removed the "py-multibase" dependency, but it's needed in https://github.com/hyperledger-labs/did-webs-resolver/blob/main/src/dkr/core/didding.py#L11 (at least for now).