### PR TITLE
Add "versionId" DID document metadata property

### DIFF
--- a/src/dkr/core/didding.py
+++ b/src/dkr/core/didding.py
@@ -83,7 +83,8 @@ def generateDIDDoc(hby, did, aid, oobi=None, metadata=None):
         retrieved=helping.nowIso8601()
     )
     didDocumentMetadata = dict(
-        witnesses=witnesses
+        witnesses=witnesses,
+        versionId=f"{kever.sner.num}"
     )
     diddoc = dict(
         id=did,


### PR DESCRIPTION
See spec support for "versionId" DID document metadata property: https://github.com/trustoverip/tswg-did-method-webs-specification/pull/49