### PR TITLE
Transform to/from did:web document

### DIFF
--- a/src/dkr/app/cli/commands/did/webs/generate.py
+++ b/src/dkr/app/cli/commands/did/webs/generate.py
@@ -87,7 +87,7 @@ class Generator(doing.DoDoer):
         
         dd_file_path = os.path.join(dd_dir_path, f"{webbing.DID_JSON}")
         ddf = open(dd_file_path, "w")
-        json.dump(diddoc, ddf)
+        json.dump(didding.toDidWeb(diddoc), ddf)
         
         kever = self.hby.kevers[aid]
 

--- a/src/dkr/app/cli/commands/did/webs/resolve.py
+++ b/src/dkr/app/cli/commands/did/webs/resolve.py
@@ -62,7 +62,7 @@ class Resolver(doing.DoDoer):
         # Load the did doc
         dd_url = f"{base_url}/{webbing.DID_JSON}"
         print(f"Loading DID Doc from {dd_url}")
-        dd_actual = json.loads(self.loadUrl(dd_url).decode("utf-8"))
+        dd_actual = didding.fromDidWeb(json.loads(self.loadUrl(dd_url).decode("utf-8")))
 
         # Load the KERI CESR
         kc_url = f"{base_url}/{webbing.KERI_CESR}"

--- a/src/dkr/core/didding.py
+++ b/src/dkr/core/didding.py
@@ -136,3 +136,15 @@ def generateDIDDoc(hby, did, aid, oobi=None, metadata=None):
         return resolutionResult
     else:
         return diddoc
+
+def toDidWeb(diddoc):
+    diddoc['id'] = diddoc['id'].replace('did:webs', 'did:web')
+    for verificationMethod in diddoc['verificationMethod']:
+        verificationMethod['controller'] = verificationMethod['controller'].replace('did:webs', 'did:web')
+    return diddoc
+
+def fromDidWeb(diddoc):
+    diddoc['id'] = diddoc['id'].replace('did:web', 'did:webs')
+    for verificationMethod in diddoc['verificationMethod']:
+        verificationMethod['controller'] = verificationMethod['controller'].replace('did:web', 'did:webs')
+    return diddoc


### PR DESCRIPTION
With this change, the DID document on the server is transformed to a did:web DID document (to be compatible with the did:web method), and when resolving it, it is transformed back to a did:webs DID document.

See corresponding spec change: https://github.com/trustoverip/tswg-did-method-webs-specification/pull/40