### PR TITLE
Updates for "resolve" and "resolver-service" components

### DIFF
--- a/src/dkr/app/cli/commands/did/keri/resolve.py
+++ b/src/dkr/app/cli/commands/did/keri/resolve.py
@@ -68,11 +68,13 @@ class KeriResolver(doing.DoDoer):
         while self.hby.db.roobi.get(keys=(self.oobi,)) is None:
             _ = yield tock
 
-        dd = didding.generateDIDDoc(self.hby, did=self.did, aid=aid, oobi=self.oobi, metadata=self.metadata)
-        data = json.dumps(dd, indent=2)
+        didresult = didding.generateDIDDoc(self.hby, did=self.did, aid=aid, oobi=self.oobi, metadata=True)
+        dd = didresult['didDocument']
+        result = didresult if self.metadata else dd
+        data = json.dumps(result, indent=2)
 
         print(data)
         self.remove(self.toRemove)
-        return dd
+        return result
 
 

--- a/src/dkr/app/cli/commands/did/keri/resolve.py
+++ b/src/dkr/app/cli/commands/did/keri/resolve.py
@@ -5,6 +5,7 @@ dkr.app.cli.commands module
 """
 import argparse
 import json
+import sys
 
 from hio.base import doing
 from keri.app import habbing, oobiing
@@ -57,8 +58,8 @@ class KeriResolver(doing.DoDoer):
         _ = (yield self.tock)
 
         aid = didding.parseDIDKeri(self.did)
-        print(f"From arguments got aid: {aid}")
-        print(f"From arguments got oobi: {self.oobi}")
+        print(f"From arguments got aid: {aid}", file=sys.stderr)
+        print(f"From arguments got oobi: {self.oobi}", file=sys.stderr)
 
         obr = basing.OobiRecord(date=helping.nowIso8601())
         obr.cid = aid

--- a/src/dkr/app/cli/commands/did/keri/resolve.py
+++ b/src/dkr/app/cli/commands/did/keri/resolve.py
@@ -31,11 +31,11 @@ parser.add_argument("--metadata", "-m", help="Whether to include metadata (True)
 
 
 def handler(args):
-    res = Resolver(name=args.name, base=args.base, bran=args.bran, did=args.did, oobi=args.oobi, metadata=args.metadata)
+    res = KeriResolver(name=args.name, base=args.base, bran=args.bran, did=args.did, oobi=args.oobi, metadata=args.metadata)
     return [res]
 
 
-class Resolver(doing.DoDoer):
+class KeriResolver(doing.DoDoer):
 
     def __init__(self, name, base, bran, did, oobi, metadata):
 
@@ -48,7 +48,7 @@ class Resolver(doing.DoDoer):
 
         self.toRemove = [hbyDoer] + obl.doers
         doers = list(self.toRemove) + [doing.doify(self.resolve)]
-        super(Resolver, self).__init__(doers=doers)
+        super(KeriResolver, self).__init__(doers=doers)
 
     def resolve(self, tymth, tock=0.0, **opts):
         self.wind(tymth)
@@ -66,11 +66,11 @@ class Resolver(doing.DoDoer):
         while self.hby.db.roobi.get(keys=(self.oobi,)) is None:
             _ = yield tock
 
-        result = didding.generateDIDDoc(self.hby, did=self.did, aid=aid, oobi=self.oobi, metadata=self.metadata)
-        data = json.dumps(result, indent=2)
+        dd = didding.generateDIDDoc(self.hby, did=self.did, aid=aid, oobi=self.oobi, metadata=self.metadata)
+        data = json.dumps(dd, indent=2)
 
         print(data)
         self.remove(self.toRemove)
-        return True
+        return dd
 
 

--- a/src/dkr/app/cli/commands/did/keri/resolve.py
+++ b/src/dkr/app/cli/commands/did/keri/resolve.py
@@ -31,17 +31,18 @@ parser.add_argument("--metadata", "-m", help="Whether to include metadata (True)
 
 
 def handler(args):
-    res = KeriResolver(name=args.name, base=args.base, bran=args.bran, did=args.did, oobi=args.oobi, metadata=args.metadata)
+    hby = existing.setupHby(name=args.name, base=args.base, bran=args.bran)
+    hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
+    obl = oobiing.Oobiery(hby=hby)
+    res = KeriResolver(hby=hby, hbyDoer=hbyDoer, obl=obl, did=args.did, oobi=args.oobi, metadata=args.metadata)
     return [res]
 
 
 class KeriResolver(doing.DoDoer):
 
-    def __init__(self, name, base, bran, did, oobi, metadata):
+    def __init__(self, hby, hbyDoer, obl, did, oobi, metadata):
 
-        self.hby = existing.setupHby(name=name, base=base, bran=bran)
-        hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
-        obl = oobiing.Oobiery(hby=self.hby)
+        self.hby = hby
         self.did = did
         self.oobi = oobi
         self.metadata = metadata

--- a/src/dkr/app/cli/commands/did/keri/resolver-service.py
+++ b/src/dkr/app/cli/commands/did/keri/resolver-service.py
@@ -71,7 +71,7 @@ def launch(args, expire=0.0):
     obl = oobiing.Oobiery(hby=hby)
 
     doers = obl.doers + [hbyDoer]
-    doers += resolving.setup(hby, httpPort=httpPort)
+    doers += resolving.setup(hby, args, httpPort=httpPort)
 
     print(f"Launched did:keri resolver as an HTTP web service on {httpPort}")
     return doers

--- a/src/dkr/app/cli/commands/did/keri/resolver-service.py
+++ b/src/dkr/app/cli/commands/did/keri/resolver-service.py
@@ -9,8 +9,6 @@ from keri.app import keeping, habbing, directing, configing, oobiing
 from keri.app.cli.common import existing
 
 from dkr.core import resolving
-from dkr.app.cli.commands.did.keri.resolve import KeriResolver
-from dkr.app.cli.commands.did.webs.resolve import WebsResolver
 
 parser = argparse.ArgumentParser(description='Expose did:keri resolver as an HTTP web service')
 parser.set_defaults(handler=lambda args: launch(args),

--- a/src/dkr/app/cli/commands/did/keri/resolver-service.py
+++ b/src/dkr/app/cli/commands/did/keri/resolver-service.py
@@ -9,6 +9,8 @@ from keri.app import keeping, habbing, directing, configing, oobiing
 from keri.app.cli.common import existing
 
 from dkr.core import resolving
+from dkr.app.cli.commands.did.keri.resolve import KeriResolver
+from dkr.app.cli.commands.did.webs.resolve import WebsResolver
 
 parser = argparse.ArgumentParser(description='Expose did:keri resolver as an HTTP web service')
 parser.set_defaults(handler=lambda args: launch(args),
@@ -71,7 +73,7 @@ def launch(args, expire=0.0):
     obl = oobiing.Oobiery(hby=hby)
 
     doers = obl.doers + [hbyDoer]
-    doers += resolving.setup(hby, args, httpPort=httpPort)
+    doers += resolving.setup(hby, hbyDoer, obl, httpPort=httpPort)
 
     print(f"Launched did:keri resolver as an HTTP web service on {httpPort}")
     return doers

--- a/src/dkr/app/cli/commands/did/webs/resolve.py
+++ b/src/dkr/app/cli/commands/did/webs/resolve.py
@@ -32,11 +32,11 @@ parser.add_argument("--metadata", "-m", help="Whether to include metadata (True)
 
 
 def handler(args):
-    res = Resolver(name=args.name, base=args.base, bran=args.bran, did=args.did)
+    res = WebsResolver(name=args.name, base=args.base, bran=args.bran, did=args.did)
     return [res]
 
 
-class Resolver(doing.DoDoer):
+class WebsResolver(doing.DoDoer):
 
     def __init__(self, name, base, bran, did, metadata):
 
@@ -48,7 +48,7 @@ class Resolver(doing.DoDoer):
 
         self.toRemove = [hbyDoer] + obl.doers
         doers = list(self.toRemove) + [doing.doify(self.resolve)]
-        super(Resolver, self).__init__(doers=doers)
+        super(WebsResolver, self).__init__(doers=doers)
 
     def resolve(self, tymth, tock=0.0, **opts):
         self.wind(tymth)

--- a/src/dkr/app/cli/commands/did/webs/resolve.py
+++ b/src/dkr/app/cli/commands/did/webs/resolve.py
@@ -32,17 +32,18 @@ parser.add_argument("--metadata", "-m", help="Whether to include metadata (True)
 
 
 def handler(args):
-    res = WebsResolver(name=args.name, base=args.base, bran=args.bran, did=args.did)
+    hby = existing.setupHby(name=args.name, base=args.base, bran=args.bran)
+    hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
+    obl = oobiing.Oobiery(hby=hby)
+    res = WebsResolver(hby=hby, hbyDoer=hbyDoer, obl=obl, did=args.did)
     return [res]
 
 
 class WebsResolver(doing.DoDoer):
 
-    def __init__(self, name, base, bran, did, metadata):
+    def __init__(self, hby, hbyDoer, obl, did):
 
-        self.hby = existing.setupHby(name=name, base=base, bran=bran)
-        hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
-        obl = oobiing.Oobiery(hby=self.hby)
+        self.hby = hby
         self.did = did
         self.metadata = metadata
 

--- a/src/dkr/app/cli/commands/did/webs/resolve.py
+++ b/src/dkr/app/cli/commands/did/webs/resolve.py
@@ -109,27 +109,27 @@ class WebsResolver(doing.DoDoer):
             return True
         
 def compare_dicts(expected, actual, path=""):
-    print("Comparing dictionaries:\nexpected:\n{expected} \nand\n \nactual:\n{actual}")
+    print("Comparing dictionaries:\nexpected:\n{expected} \nand\n \nactual:\n{actual}", file=sys.stderr)
     
     """Recursively compare two dictionaries and print differences."""
     for k in expected.keys():
         # Construct current path
         current_path = f"{path}.{k}" if path else k
-        print(f"Comparing key {current_path}")
+        print(f"Comparing key {current_path}", file=sys.stderr)
 
         # Key not present in the actual dictionary
         if k not in actual:
-            print(f"Key {current_path} not found in the actual dictionary")
+            print(f"Key {current_path} not found in the actual dictionary", file=sys.stderr)
             continue
 
         # If value in expected is a dictionary but not in actual
         if isinstance(expected[k], dict) and not isinstance(actual[k], dict):
-            print(f"{current_path} is a dictionary in expected, but not in actual")
+            print(f"{current_path} is a dictionary in expected, but not in actual", file=sys.stderr)
             continue
 
         # If value in actual is a dictionary but not in expected
         if isinstance(actual[k], dict) and not isinstance(expected[k], dict):
-            print(f"{current_path} is a dictionary in actual, but not in expected")
+            print(f"{current_path} is a dictionary in actual, but not in expected", file=sys.stderr)
             continue
 
         # If value is another dictionary, recurse
@@ -137,13 +137,13 @@ def compare_dicts(expected, actual, path=""):
             compare_dicts(expected[k], actual[k], current_path)
         # Compare non-dict values
         elif expected[k] != actual[k]:
-            print(f"Different values for key {current_path}: {expected[k]} (expected) vs. {actual[k]} (actual)")
+            print(f"Different values for key {current_path}: {expected[k]} (expected) vs. {actual[k]} (actual)", file=sys.stderr)
 
     # Check for keys in actual that are not present in expected
     for k in actual.keys():
         current_path = f"{path}.{k}" if path else k
         if k not in expected:
-            print(f"Key {current_path} not found in the expected dictionary")
+            print(f"Key {current_path} not found in the expected dictionary", file=sys.stderr)
 
 # # Test with the provided dictionaries
 # expected_dict = {

--- a/src/dkr/app/cli/commands/did/webs/resolver-service.py
+++ b/src/dkr/app/cli/commands/did/webs/resolver-service.py
@@ -16,7 +16,7 @@ parser.set_defaults(handler=lambda args: launch(args),
 parser.add_argument('-p', '--http',
                     action='store',
                     default=7677,
-                    help="Port on which to listen for did:webs resolution requests.  Defaults to 967")
+                    help="Port on which to listen for did:webs resolution requests.  Defaults to 7677")
 parser.add_argument('-n', '--name',
                     action='store',
                     default="dkr",
@@ -71,7 +71,7 @@ def launch(args, expire=0.0):
     obl = oobiing.Oobiery(hby=hby)
 
     doers = obl.doers + [hbyDoer]
-    doers += resolving.setup(hby, httpPort=httpPort)
+    doers += resolving.setup(hby, args, httpPort=httpPort)
 
     print(f"Launched did:webs resolver as an HTTP web service on {httpPort}")
     return doers

--- a/src/dkr/app/cli/commands/did/webs/resolver-service.py
+++ b/src/dkr/app/cli/commands/did/webs/resolver-service.py
@@ -71,7 +71,7 @@ def launch(args, expire=0.0):
     obl = oobiing.Oobiery(hby=hby)
 
     doers = obl.doers + [hbyDoer]
-    doers += resolving.setup(hby, args, httpPort=httpPort)
+    doers += resolving.setup(hby, hbyDoer, obl, httpPort=httpPort)
 
     print(f"Launched did:webs resolver as an HTTP web service on {httpPort}")
     return doers

--- a/src/dkr/core/resolving.py
+++ b/src/dkr/core/resolving.py
@@ -4,6 +4,7 @@ dkr.core.serving module
 
 """
 import json
+import os
 
 import falcon
 from hio.base import doing
@@ -84,14 +85,22 @@ class ResolveResource(doing.DoDoer):
         else:
             oobi = None
 
+        metadata = False
+
         if did.startswith('did:webs:'):
-            res = WebsResolver(hby=self.hby, hbyDoer=self.hbyDoer, obl=self.obl, did=did)
-            tymth = None # ???
-            data = res.resolve(tymth)
+            #res = WebsResolver(hby=self.hby, hbyDoer=self.hbyDoer, obl=self.obl, did=did)
+            #tymth = None # ???
+            #data = res.resolve(tymth)
+            cmd = f"dkr did webs resolve --name dkr --did {did} --metadata {metadata}"
+            stream = os.popen(cmd)
+            data = stream.read()
         elif did.startswith('did:keri'):
-            res = KeriResolver(hby=self.hby, hbyDoer=self.hbyDoer, obl=self.obl, did=did, oobi=oobi, metadata=False)
-            tymth = None # ???
-            data = res.resolve(tymth)
+            #res = KeriResolver(hby=self.hby, hbyDoer=self.hbyDoer, obl=self.obl, did=did, oobi=oobi, metadata=False)
+            #tymth = None # ???
+            #data = res.resolve(tymth)
+            cmd = f"dkr did keri resolve --name dkr --did {did} --oobi {oobi} --metadata {metadata}"
+            stream = os.popen(cmd)
+            data = stream.read()
         else:
             rep.status = falcon.HTTP_400
             rep.text = "invalid 'did'"

--- a/src/dkr/core/resolving.py
+++ b/src/dkr/core/resolving.py
@@ -16,7 +16,7 @@ from dkr.app.cli.commands.did.webs.resolve import WebsResolver
 from dkr.core import didding
 
 
-def setup(hby, args, *, httpPort):
+def setup(hby, hbyDoer, obl, *, httpPort):
     """ Setup serving package and endpoints
 
     Parameters:
@@ -34,16 +34,16 @@ def setup(hby, args, *, httpPort):
     server = http.Server(port=httpPort, app=app)
     httpServerDoer = http.ServerDoer(server=server)
 
-    loadEnds(app, hby=hby, args=args)
+    loadEnds(app, hby=hby, hbyDoer=hbyDoer, obl=obl)
 
     doers = [httpServerDoer]
 
     return doers
 
 
-def loadEnds(app, *, hby, args, prefix=""):
+def loadEnds(app, *, hby, hbyDoer, obl, prefix=""):
     print(f"Loading resolving endpoints")
-    resolveEnd = ResolveResource(hby=hby, args=args)
+    resolveEnd = ResolveResource(hby=hby, hbyDoer=hbyDoer, obl=obl)
     result = app.add_route('/1.0/identifiers/{did}', resolveEnd)
     print(f"Loaded resolving endpoints: {app}")
 
@@ -56,7 +56,7 @@ class ResolveResource(doing.DoDoer):
 
     """
 
-    def __init__(self, hby, args):
+    def __init__(self, hby, hbyDoer, obl):
         """ Create Endpoints for discovery and resolution of OOBIs
 
         Parameters:
@@ -64,7 +64,8 @@ class ResolveResource(doing.DoDoer):
 
         """
         self.hby = hby
-        self.args = args
+        self.hbyDoer = hbyDoer
+        self.obl = obl
 
         super(ResolveResource, self).__init__(doers=[])
         print(f"Init resolver endpoint")
@@ -84,11 +85,11 @@ class ResolveResource(doing.DoDoer):
             oobi = None
 
         if did.startswith('did:webs:'):
-            res = WebsResolver(name=self.args.name, base=self.args.base, bran=self.args.bran, did=did, oobi=oobi, metadata=False)
+            res = WebsResolver(hby=self.hby, hbyDoer=self.hbyDoer, obl=self.obl, did=did)
             tymth = None # ???
             data = res.resolve(tymth)
         elif did.startswith('did:keri'):
-            res = KeriResolver(name=self.args.name, base=self.args.base, bran=self.args.bran, did=did, oobi=oobi, metadata=False)
+            res = KeriResolver(hby=self.hby, hbyDoer=self.hbyDoer, obl=self.obl, did=did, oobi=oobi, metadata=False)
             tymth = None # ???
             data = res.resolve(tymth)
         else:


### PR DESCRIPTION
This has various updates related to the "resolve" functionality, including for DID document metadata.

It also updates the "resolver-service" functionality, which makes it possible to run did:keri and did:webs drivers for the Universal Resolver.

This is the state of the code that was used for IIW37 and this tutorial: https://github.com/peacekeeper/did-webs-iiw37-tutorial