### PR TITLE
Removed numpy as a dependency with math.lcm from stdlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
                         'http_sfv>=0.9.8',
                         'cryptography>=39.0.2',
                         'requests>=2.28',
-                        'numpy>=1.26.0',
                         'pytest>=6.2.5',
                         'pytest-timeout>=2.3.1'
     ],

--- a/src/dkr/core/didding.py
+++ b/src/dkr/core/didding.py
@@ -6,8 +6,8 @@ dkr.core.didding module
 
 from datetime import datetime
 import json
+import math
 import re
-import numpy as np
 
 from base64 import urlsafe_b64encode
 
@@ -112,7 +112,7 @@ def generateDIDDoc(hby: habbing.Habery, did, aid, oobi=None, metadata=None, reg_
                 conditionThreshold=conditions
             ))
     elif isinstance(kever.tholder.thold, list):
-        lcd = int(np.lcm.reduce([fr.denominator for fr in kever.tholder.thold[0]]))
+        lcd = int(math.lcm(*[fr.denominator for fr in kever.tholder.thold[0]]))
         threshold = float(lcd/2)
         numerators = [int(fr.numerator * lcd / fr.denominator) for fr in kever.tholder.thold[0]]
         conditions = []


### PR DESCRIPTION
I couldn't get the tests to run locally correctly but this should remove numpy as a heavy dependency in favor of the math library in stdlib.  Assuming we're not calculating the lcm on a terabyte of data this should be fine.