### PR TITLE
Updated call bc datetime.utcnow() to be deprecated

### DIFF
--- a/src/dkr/core/didding.py
+++ b/src/dkr/core/didding.py
@@ -4,7 +4,7 @@ dkr.core.didding module
 
 """
 
-from datetime import datetime
+import datetime
 import json
 import math
 import re
@@ -164,7 +164,7 @@ def generateDIDDoc(hby: habbing.Habery, did, aid, oobi=None, metadata=None, reg_
             
     didResolutionMetadata = dict(
         contentType="application/did+json",
-        retrieved=datetime.utcnow().strftime(DID_TIME_FORMAT)
+        retrieved=datetime.datetime.now(datetime.UTC).strftime(DID_TIME_FORMAT)
     )
     didDocumentMetadata = dict(
         witnesses=witnesses,


### PR DESCRIPTION
This PR gets rid of the warning emitted as old style of calling to be deprecated.