### PR TITLE
fix: #72 fixed with datetime.timezone.utc

### DIFF
--- a/src/dkr/core/didding.py
+++ b/src/dkr/core/didding.py
@@ -164,7 +164,7 @@ def generateDIDDoc(hby: habbing.Habery, did, aid, oobi=None, meta=False, reg_nam
             
     didResolutionMetadata = dict(
         contentType="application/did+json",
-        retrieved=datetime.datetime.now(datetime.UTC).strftime(DID_TIME_FORMAT)
+        retrieved=datetime.datetime.now(datetime.timezone.utc).strftime(DID_TIME_FORMAT)
     )
     didDocumentMetadata = dict(
         witnesses=witnesses,


### PR DESCRIPTION
This one line fix resolves the error mentioned in #72 . The UTC property is not exposed on the `datetime` module and using `datetime.timezone.utc` works for me.